### PR TITLE
Fixed the bug #3901 on XP

### DIFF
--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -129,7 +129,7 @@ void FileAccessWindows::close() {
 			rename_error = _wrename((save_path+".tmp").c_str(),save_path.c_str())!=0;
 		} else {
 			//atomic replace for existing file
-			rename_error = !ReplaceFileW(save_path.c_str(), (save_path+".tmp").c_str(), NULL, 2|4, NULL, NULL);
+			rename_error = !ReplaceFileW(save_path.c_str(), (save_path+".tmp").c_str(), NULL, 2, NULL, NULL);
 		}
 		save_path="";
 		ERR_FAIL_COND( rename_error );


### PR DESCRIPTION
according to MSDN if flag 2 is specified then flag 4 is superfluous and it causes bug on XP
